### PR TITLE
Checking for nil case

### DIFF
--- a/lib/attr_sanitizable.rb
+++ b/lib/attr_sanitizable.rb
@@ -13,11 +13,13 @@ module AttrSanitizable
 
       attributes.each do |field|
         define_method "#{field}=" do |value|
-          actions.each do |action|
-            if !value.respond_to?(action)
-              raise ArgumentError, "Unable to perform '#{action}' on a variable of type '#{value.class.name}'"
+          if !value.nil?
+            actions.each do |action|
+              if !value.respond_to?(action)
+                raise ArgumentError, "Unable to perform '#{action}' on a variable of type '#{value.class.name}'"
+              end
+              value = value.try(action)
             end
-            value = value.try(action)
           end
           write_attribute(field, value)
         end

--- a/spec/attr_sanitizable_spec.rb
+++ b/spec/attr_sanitizable_spec.rb
@@ -30,6 +30,18 @@ describe AttrSanitizable do
     }.to raise_error(ArgumentError, "Unable to perform 'not_defined' on a variable of type 'String'")
   end
 
+  describe "when nil" do
+    it "skips sanitizables" do
+      class User < ActiveRecord::Base
+        attr_sanitizable :email, with: [:strip]
+      end
+
+      user = User.new
+      user.email = nil
+      user.email.should eq(nil)
+    end
+  end
+
   it "custom functions" do
     class String
       def troll


### PR DESCRIPTION
Nil doesn't have any of the sanitizable methods most likely, so skip them when the value being set is nil.
